### PR TITLE
Remove "Plugin" suffix from plugin name

### DIFF
--- a/com.obsproject.Studio.Plugin.Gstreamer.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.Gstreamer.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>com.obsproject.Studio.Plugin.Gstreamer</id>
   <extends>com.obsproject.Studio</extends>
-  <name>GStreamer Plugin</name>
+  <name>GStreamer</name>
   <summary>Encode streams and recordings using GStreamer</summary>
   <url type="homepage">https://github.com/fzwoch/obs-gstreamer</url>
   <releases>


### PR DESCRIPTION
It is already displayed under the "Plugins" section in app stores like GNOME Software and KDE's Discover. The new policy on Flathub for OBS Studio plugins is not to have this suffix too.